### PR TITLE
fix(worker): 🔧 update `primaryDone` callback to `done`

### DIFF
--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -136,7 +136,7 @@ var primaryWork = function(db, pods, members, shouldForce, done) {
   var addrToRemove = addrToRemoveLoop(members);
 
   if (addrToAdd.length || addrToRemove.length) {
-    mongo.addNewReplSetMembers(db, addrToAdd, addrToRemove, shouldForce, primaryDone);
+    mongo.addNewReplSetMembers(db, addrToAdd, addrToRemove, shouldForce, done);
     return;
   }
 


### PR DESCRIPTION
* Changed the callback in `mongo.addNewReplSetMembers` from `primaryDone` to `done` for consistency.
* Ensures proper handling of completion in the primary work function.